### PR TITLE
Add support for nonlinear pipelines

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If you'd like to use this package, you can follow the `example.py` below:
 ```python
 from tinypipeline import pipeline, step
 
+# define all of the steps
 @step(name='step_one', version='0.0.1', description='first step')
 def step_one():
     print("Step function one")
@@ -35,17 +36,52 @@ def step_one():
 def step_two():
     print("Step function two")
 
+@step(name='step_three', version='0.0.1', description='third step')
+def step_three():
+    print("Step function three")
+
+@step(name='step_four', version='0.0.1', description='fourth step')
+def step_four():
+    print("Step function four")
+
+
+# define the pipeline
 @pipeline(
     name='test-pipeline', 
     version='0.0.1', 
     description='a test tinypipeline',
 )
 def pipe():
-    return [step_one, step_two]
+    # run the steps in the defined order
+    return [
+        step_one, 
+        step_two, 
+        step_three, 
+        step_four,
+    ]
 
 pipe = pipe()
 pipe.run()
 ```
+
+You can also define steps using a dictionary, where each key of the dictionary
+is a step to run, and the values are steps that run after the step named in the key.
+
+```python
+# define the pipeline
+@pipeline(
+    name='test-pipeline', 
+    version='0.0.1', 
+    description='a test tinypipeline',
+)
+def pipe():
+    # run the steps in the defined order of the graph
+    return {
+        step_one: [step_two, step_four],
+        step_two: [step_three, step_four]
+    }
+```
+
 
 **Output**:
 
@@ -59,11 +95,19 @@ $ python example.py
 
 Running step [step_one]...
 Step function one
-Step [step_one] completed in 0.000356 seconds
+Step [step_one] completed in 0.000325 seconds
 
 Running step [step_two]...
 Step function two
-Step [step_two] completed in 0.000317 seconds
+Step [step_two] completed in 0.000286 seconds
+
+Running step [step_three]...
+Step function three
+Step [step_three] completed in 0.000251 seconds
+
+Running step [step_four]...
+Step function four
+Step [step_four] completed in 0.000313 seconds
 ```
 
 ## Running tests
@@ -74,7 +118,3 @@ Tests are run using pytest. To run the tests you can do:
 $ pip install pytest
 $ pytest
 ```
-
-## Limitations
-
-- Currently `tinypipeline` only supports linear pipelines, and doesn't support full dependency graphs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "A tiny mlops library for building machine learning pipelines on your local machine."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 keywords = ["mlops", "machine learning", "pipelines"]
 license = {text = "MIT"}
 classifiers = [

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -36,7 +36,7 @@ def test_pipeline_completion():
             description="Step two",
             version="1.0.0",
         )
-    
+
         step_three = step(
             callable=mock_step_3,
             name="step_three",
@@ -105,7 +105,82 @@ def test_pipeline_completion_using_step_decorator():
     assert len(pipe.steps) == 3
     mock_step_1.assert_called_once()
     mock_step_2.assert_called_once()
-    mock_step_3.assert_called_once() 
+    mock_step_3.assert_called_once()
+
+
+def test_pipeline_completion_with_dict_ordering():
+    """
+    Test that the pipeline runs all the steps in the correct order,
+    defined by a dictionary that has the steps as keys and the steps
+    that depend on them as values.
+
+    Ensure the topological ordering is correct.
+    """
+    mock_step_1 = Mock()
+    mock_step_2 = Mock()
+    mock_step_3 = Mock()
+    mock_step_4 = Mock()
+    mock_step_5 = Mock()
+
+    mock_step_1.return_value = "step 1"
+    mock_step_2.return_value = "step 2"
+    mock_step_3.return_value = "step 3"
+    mock_step_4.return_value = "step 4"
+    mock_step_5.return_value = "step 5"
+
+    @step(name="step_one", description="Step one", version="1.0.0")
+    def step_one():
+        mock_step_1()
+
+    @step(name="step_two", description="Step two", version="1.0.0")
+    def step_two():
+        mock_step_2()
+
+    @step(name="step_three", description="Step three", version="1.0.0")
+    def step_three():
+        mock_step_3()
+
+    @step(name="step_four", description="Step four", version="1.0.0")
+    def step_four():
+        mock_step_4()
+
+    @step(name="step_five", description="Step five", version="1.0.0")
+    def step_five():
+        mock_step_5()
+
+    @pipeline(
+        name="test_pipeline",
+        description="Test pipeline",
+        version="1.0.0",
+    )
+    def test_pipeline():
+        """
+        Run the steps in the following order:
+        step_five -> step_two -> step_three -> step_four -> step_one
+        """
+        return {
+            step_five: [step_two],
+            step_two: [step_three],
+            step_three: [step_four, step_one],
+            step_four: [step_one],
+        }
+
+    pipe = test_pipeline()
+    pipe.run()
+
+    steps = []
+    for key, value in pipe.steps.items():
+        steps.append(key)
+        steps.extend(value)
+
+    steps = set(steps)
+
+    assert len(steps) == 5
+    mock_step_1.assert_called_once()
+    mock_step_2.assert_called_once()
+    mock_step_3.assert_called_once()
+    mock_step_4.assert_called_once()
+    mock_step_5.assert_called_once()
 
 def test_pipeline_failure_no_function_passed():
     """
@@ -154,12 +229,22 @@ def test_pipeline_failure_invalid_step():
         == str(context.value)
     )
 
-def test_pipeline_failure_no_steps_list():
+def test_pipeline_failure_no_steps_list_or_dict():
     """
-    Test that the pipeline fails with a TypeError if there is no list of steps.
+    Test that the pipeline fails with a TypeError if there are no
+    steps in a list or a dictionary.
 
     Also check that the error message is correct.
     """
+    # create step one
+    @step(
+        name="step_one",
+        description="Step one",
+        version="1.0.0",
+    )
+    def step_one():
+        pass
+
 
     @pipeline(
         name="test_pipeline",
@@ -167,13 +252,13 @@ def test_pipeline_failure_no_steps_list():
         version="1.0.0",
     )
     def test_pipeline():
-        return "step_one"
+        return step_one
 
     with pytest.raises(TypeError) as context:
         pipe = test_pipeline()
         pipe.run()
 
-    assert "Pipeline steps must be in a list." == str(context.value)
+    assert "Pipeline steps must be in a list or a dict." == str(context.value)
 
 def test_pipeline_failure_no_steps_to_run():
     """

--- a/tinypipeline/pipeline.py
+++ b/tinypipeline/pipeline.py
@@ -1,7 +1,7 @@
 import functools
 
 from datetime import datetime
-from typing import Callable
+from typing import Callable, Union, Dict, List
 
 from .step import Step
 
@@ -36,7 +36,19 @@ class Pipeline:
         self.version = version
         self.description = description
 
-        self.steps = self._get_steps()
+    @functools.cached_property
+    def steps(self) -> Union[List[Step], Dict[Step, Step]]:
+        """
+        The steps for the pipeline. Cached property so that the function
+        containing the steps is only called once.
+
+        Returns
+        -------
+        Union[List[Step], Dict[Step, Step]]
+            The steps for the pipeline.
+        """
+        return self._func()
+
 
     def __repr__(self):
         """

--- a/tinypipeline/pipeline.py
+++ b/tinypipeline/pipeline.py
@@ -49,6 +49,24 @@ class Pipeline:
         """
         return self._func()
 
+    @property
+    def ordering(self) -> str:
+        """
+        The ordering of the steps in the pipeline. Either linear or nonlinear.
+
+        Returns
+        -------
+        str
+            'linear' or 'nonlinear'.
+        """
+        if isinstance(self.steps, List):
+            _ordering = 'linear'
+        elif isinstance(self.steps, Dict):
+            _ordering = 'nonlinear'
+        else:
+            raise TypeError("Pipeline steps must be in a list or a dict.")
+
+        return _ordering
 
     def __repr__(self):
         """

--- a/tinypipeline/step.py
+++ b/tinypipeline/step.py
@@ -28,6 +28,12 @@ class Step:
         self.version = version
         self.description = description
 
+    def __repr__(self):
+        """
+        Representation of the step.
+        """
+        return f"Step(name='{self.name}', version='{self.version}')"
+
     def run(self):
         """
         Run the step.


### PR DESCRIPTION
# Context

Currently, pipelines can only be created / set up as lists of steps. However, I think having some added flexibility for non-linear pipelines would be good. I'm working on a project where being able to define step ordering via dependencies rather than linear ordering makes more sense.

## Changes in this PR

- Adds an `ordering` property to the `Pipeline` class
- Adds support for nonlinear pipelines via a dictionary (adjacency matrix) whose dependencies get topologically sorted
- Drops Python 3.8 support to take advantage of the built-in `graphlib` for Python 3.9+
- Adds Python 3.11 support
- Updates tests
- Adds a `repr` method for `Step` instances